### PR TITLE
LRU to work with generics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,31 +1,23 @@
-# Mac OS X files
-.DS_Store
-
-# IDE files
-.idea/
-.vscode/
-.history/
-*.vsix
-.ionide
-
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
 *.so
-*.dylib
 
-# Test binary, build with `go test -c`
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
 *.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-coverage.html
-
-# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
-.glide/
-
-# Dependency directories
-vendor/
-
-__debug_bin

--- a/2q.go
+++ b/2q.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/descope/golang-lru/simplelru"
+	"github.com/hashicorp/golang-lru/simplelru"
 )
 
 const (

--- a/arc.go
+++ b/arc.go
@@ -3,7 +3,7 @@ package lru
 import (
 	"sync"
 
-	"github.com/descope/golang-lru/simplelru"
+	"github.com/hashicorp/golang-lru/simplelru"
 )
 
 // ARCCache is a thread-safe fixed size Adaptive Replacement Cache (ARC).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/descope/golang-lru
+module github.com/hashicorp/golang-lru
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/golang-lru
+module github.com/viktordanov/golang-lru
 
 go 1.18
 

--- a/lru.go
+++ b/lru.go
@@ -3,7 +3,7 @@ package lru
 import (
 	"sync"
 
-	"github.com/descope/golang-lru/simplelru"
+	"github.com/hashicorp/golang-lru/simplelru"
 )
 
 const (


### PR DESCRIPTION
Added generics for all levels of LRU implementation
For internal list, moved from GO built in containers/list to a generic implementation:
github.com/bahlo/generic-list-go
Updated all tests to accomodate generics
In go.mod changed go version to 1.18